### PR TITLE
fix: resolve Clippy items_after_test_module and rustls-webpki advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/event.rs
+++ b/src/event.rs
@@ -315,10 +315,8 @@ async fn handle_host_select_mode(app: &mut App, code: KeyCode) -> Result<bool> {
         KeyCode::Esc | KeyCode::Char('q') => {
             app.exit_mode();
         }
-        KeyCode::Char('j') | KeyCode::Down => {
-            if !app.host_list.is_empty() {
-                app.host_select_index = (app.host_select_index + 1).min(app.host_list.len() - 1);
-            }
+        KeyCode::Char('j') | KeyCode::Down if !app.host_list.is_empty() => {
+            app.host_select_index = (app.host_select_index + 1).min(app.host_list.len() - 1);
         }
         KeyCode::Char('k') | KeyCode::Up => {
             app.host_select_index = app.host_select_index.saturating_sub(1);
@@ -326,10 +324,8 @@ async fn handle_host_select_mode(app: &mut App, code: KeyCode) -> Result<bool> {
         KeyCode::Char('g') => {
             app.host_select_index = 0;
         }
-        KeyCode::Char('G') => {
-            if !app.host_list.is_empty() {
-                app.host_select_index = app.host_list.len() - 1;
-            }
+        KeyCode::Char('G') if !app.host_list.is_empty() => {
+            app.host_select_index = app.host_list.len() - 1;
         }
         KeyCode::Enter => {
             if let Some(host) = app.selected_host().cloned() {

--- a/src/one/client.rs
+++ b/src/one/client.rs
@@ -429,6 +429,39 @@ impl OneClient {
     }
 }
 
+/// Format an OpenNebula API error for display
+/// This function sanitizes error messages to prevent information disclosure
+pub fn format_one_error(error: &anyhow::Error) -> String {
+    let error_str = error.to_string();
+
+    // Clean up common error patterns with safe messages
+    if error_str.contains("401") || error_str.contains("Authentication") {
+        return "Authentication failed. Check ONE_AUTH credentials.".to_string();
+    }
+    if error_str.contains("Connection refused") {
+        return "Connection refused. Check ONE_XMLRPC endpoint.".to_string();
+    }
+    if error_str.contains("timeout") || error_str.contains("timed out") {
+        return "Request timed out. Server may be unreachable.".to_string();
+    }
+    if error_str.contains("certificate") || error_str.contains("SSL") || error_str.contains("TLS") {
+        return "TLS/SSL error. Check certificate configuration.".to_string();
+    }
+
+    // For OpenNebula API errors, extract just the message
+    if let Some(start) = error_str.find("OpenNebula API error:") {
+        let msg = &error_str[start..];
+        // Truncate long error messages
+        if msg.len() > 100 {
+            return format!("{}...", &msg[..100]);
+        }
+        return msg.to_string();
+    }
+
+    // Generic fallback - don't expose internal details
+    "An error occurred. Check logs for details.".to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -642,37 +675,4 @@ mod tests {
             .expect("migrate should succeed");
         assert_eq!(migrate_result, serde_json::json!(100));
     }
-}
-
-/// Format an OpenNebula API error for display
-/// This function sanitizes error messages to prevent information disclosure
-pub fn format_one_error(error: &anyhow::Error) -> String {
-    let error_str = error.to_string();
-
-    // Clean up common error patterns with safe messages
-    if error_str.contains("401") || error_str.contains("Authentication") {
-        return "Authentication failed. Check ONE_AUTH credentials.".to_string();
-    }
-    if error_str.contains("Connection refused") {
-        return "Connection refused. Check ONE_XMLRPC endpoint.".to_string();
-    }
-    if error_str.contains("timeout") || error_str.contains("timed out") {
-        return "Request timed out. Server may be unreachable.".to_string();
-    }
-    if error_str.contains("certificate") || error_str.contains("SSL") || error_str.contains("TLS") {
-        return "TLS/SSL error. Check certificate configuration.".to_string();
-    }
-
-    // For OpenNebula API errors, extract just the message
-    if let Some(start) = error_str.find("OpenNebula API error:") {
-        let msg = &error_str[start..];
-        // Truncate long error messages
-        if msg.len() > 100 {
-            return format!("{}...", &msg[..100]);
-        }
-        return msg.to_string();
-    }
-
-    // Generic fallback - don't expose internal details
-    "An error occurred. Check logs for details.".to_string()
 }

--- a/src/one/xmlrpc.rs
+++ b/src/one/xmlrpc.rs
@@ -280,10 +280,10 @@ fn parse_value_content(reader: &mut quick_xml::Reader<&[u8]>) -> Result<XmlRpcVa
                     }
                     "name" => in_name = true,
                     "string" | "int" | "i4" | "boolean" | "double" | "array" | "struct"
-                    | "data" | "member" => {
-                        if current_type.is_none() {
-                            current_type = Some(tag);
-                        }
+                    | "data" | "member"
+                        if current_type.is_none() =>
+                    {
+                        current_type = Some(tag);
                     }
                     _ => {}
                 }


### PR DESCRIPTION
- Move format_one_error() above the tests module in src/one/client.rs
  to satisfy clippy::items_after_test_module under -D warnings.
- Bump rustls-webpki to 0.103.13 in Cargo.lock, addressing
  RUSTSEC-2026-0098, RUSTSEC-2026-0099, and RUSTSEC-2026-0104.