### PR TITLE
ci: grant Security Audit job checks:write to fix check-run API call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
rustsec/audit-check@v2 creates a check-run via the Checks API. The
default GITHUB_TOKEN permissions on push events to master had read-only
checks scope, causing 'Resource not accessible by integration' even
when cargo-audit itself found no vulnerabilities.

Add explicit permissions (contents: read, checks: write, issues: write)
to the security-audit job so the action can publish its results.